### PR TITLE
fix: resolve architectural violations in view-own-checklists feature

### DIFF
--- a/src/Application/UseCases/GetUserChecklists/GetUserChecklistsResult.cs
+++ b/src/Application/UseCases/GetUserChecklists/GetUserChecklistsResult.cs
@@ -2,7 +2,4 @@ using Application.DTOs.Checklist;
 
 namespace Application.UseCases.GetUserChecklists;
 
-public record GetUserChecklistsResult(
-    List<ChecklistSummaryDto> Checklists,
-    bool Succeeded = true,
-    string? ErrorMessage = null);
+public sealed record GetUserChecklistsResult(List<ChecklistSummaryDto> Checklists);

--- a/src/Web/Controllers/AuthorController.cs
+++ b/src/Web/Controllers/AuthorController.cs
@@ -34,12 +34,6 @@ public sealed class AuthorController : Controller
 
         var result = _handler.Handle(new GetUserChecklistsQuery(userId));
 
-        if (!result.Succeeded)
-        {
-            _logger.LogWarning("Failed to get checklists for user {UserId}: {Error}", userId, result.ErrorMessage);
-            return View("Error");
-        }
-
         var viewModel = new AuthorChecklistsViewModel
         {
             Checklists = result.Checklists

--- a/src/Web/Views/Author/Index.cshtml
+++ b/src/Web/Views/Author/Index.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "Author's Page";
 }
 
-<div class="container mt-4" style="max-width: 800px;">
+<div class="author-page container mt-4" style="max-width: 800px;">
     <div class="mb-3">
         <a href="@Url.Action("Index", "Home")" class="text-dark text-decoration-none fs-4">
             <i class="bi bi-chevron-left"></i> < 
@@ -65,16 +65,3 @@
     </div>
 </div>
 
-
-<style>
-    .list-group-item {
-        background-color: transparent;
-    }
-    .dropdown-item:active {
-        background-color: #e9ecef;
-        color: black;
-    }
-    h2 {
-        font-family: serif;
-    }
-</style>

--- a/src/Web/wwwroot/css/site.css
+++ b/src/Web/wwwroot/css/site.css
@@ -29,3 +29,16 @@ body {
 .form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
   text-align: start;
 }
+
+.list-group-item {
+  background-color: transparent;
+}
+
+.dropdown-item:active {
+  background-color: #e9ecef;
+  color: black;
+}
+
+.author-page h2 {
+  font-family: serif;
+}

--- a/tests/UnitTests/GetUserChecklistsQueryHandlerTests.cs
+++ b/tests/UnitTests/GetUserChecklistsQueryHandlerTests.cs
@@ -36,7 +36,6 @@ public class GetUserChecklistsQueryHandlerTests
 
         var result = _handler.Handle(new GetUserChecklistsQuery(userId));
 
-        Assert.True(result.Succeeded);
         Assert.Equal(2, result.Checklists.Count);
         Assert.Equal("Checklist 1", result.Checklists[0].Title);
         Assert.Equal("Checklist 2", result.Checklists[1].Title);
@@ -51,7 +50,6 @@ public class GetUserChecklistsQueryHandlerTests
 
         var result = _handler.Handle(new GetUserChecklistsQuery(userId));
 
-        Assert.True(result.Succeeded);
         Assert.Empty(result.Checklists);
         _repositoryMock.Verify(repo => repo.GetByUserId(userId), Times.Once);
     }


### PR DESCRIPTION
- Simplify GetUserChecklistsResult to match SearchChecklistsResult pattern (remove spurious Succeeded/ErrorMessage fields that were never set to failure)
- Remove dead result.Succeeded check from AuthorController
- Move inline <style> block from Author/Index.cshtml to site.css, scope h2 font rule to .author-page to avoid leaking globally
- Remove Assert.True(result.Succeeded) from unit tests accordingly