### PR TITLE
feat: implement checklist progress tracking on home page

### DIFF
--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="UseCases\GetChecklistsByIds\" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <Folder Include="Interfaces\" />
   </ItemGroup>

--- a/src/Application/Interfaces/IChecklistRepository.cs
+++ b/src/Application/Interfaces/IChecklistRepository.cs
@@ -8,6 +8,8 @@ public interface IChecklistRepository
 
     Task<IEnumerable<Checklist>> GetByUserIdAsync(string userId);
 
+    Task<List<Checklist>> GetByIdsAsync(IEnumerable<Guid> ids);
+
     Task AddAsync(Checklist checklist);
 
     Task DeleteAsync(Guid id);

--- a/src/Application/UseCases/GetChecklistsByIds/GetChecklistsByIdsQuery.cs
+++ b/src/Application/UseCases/GetChecklistsByIds/GetChecklistsByIdsQuery.cs
@@ -1,0 +1,6 @@
+namespace Application.UseCases.GetChecklistsByIds;
+
+public sealed class GetChecklistsByIdsQuery(List<Guid> ids)
+{
+    public List<Guid> Ids { get; } = ids;
+}

--- a/src/Application/UseCases/GetChecklistsByIds/GetChecklistsByIdsQueryHandler.cs
+++ b/src/Application/UseCases/GetChecklistsByIds/GetChecklistsByIdsQueryHandler.cs
@@ -1,0 +1,40 @@
+using Application.Common;
+using Application.DTOs.Checklist;
+using Application.Interfaces;
+using Domain.Entities;
+using Microsoft.Extensions.Logging;
+
+namespace Application.UseCases.GetChecklistsByIds;
+
+public sealed class GetChecklistsByIdsQueryHandler(
+    IChecklistRepository repository,
+    ILogger<GetChecklistsByIdsQueryHandler> logger)
+{
+    public async Task<Result<List<ChecklistSummaryDto>>> HandleAsync(GetChecklistsByIdsQuery query)
+    {
+        logger.LogInformation("Fetching checklists by IDs. Requested count: {Count}", query.Ids.Count);
+
+        if (query.Ids.Count == 0)
+        {
+            return new List<ChecklistSummaryDto>();
+        }
+
+        var checklists = await repository.GetByIdsAsync(query.Ids);
+
+        var result = checklists
+            .Where(c => c.Status == ChecklistStatus.Published)
+            .Select(c => new ChecklistSummaryDto
+            {
+                Id = c.Id,
+                Title = c.Title,
+                Description = c.Description,
+                UserId = c.UserId,
+                Status = c.Status
+            })
+            .ToList();
+
+        logger.LogInformation("Successfully retrieved {Count} published checklists from database", result.Count);
+
+        return result;
+    }
+}

--- a/src/Infrastructure/Repositories/ChecklistRepository.cs
+++ b/src/Infrastructure/Repositories/ChecklistRepository.cs
@@ -16,6 +16,11 @@ public class ChecklistRepository(ApplicationDbContext context) : IChecklistRepos
             .ToListAsync();
     }
 
+    public async Task<List<Checklist>> GetByIdsAsync(IEnumerable<Guid> ids)
+    {
+        return await context.Checklists.Where(c => ids.Contains(c.Id)).AsNoTracking().ToListAsync();
+    }
+
     public async Task AddAsync(Checklist checklist)
     {
         await context.Checklists.AddAsync(checklist);

--- a/src/Web/Controllers/ChecklistController.cs
+++ b/src/Web/Controllers/ChecklistController.cs
@@ -1,10 +1,10 @@
-using Application.Common;
 using Application.Interfaces;
 using Application.UseCases.CreateChecklist;
 using Application.UseCases.DeleteChecklist;
 using Application.UseCases.EditChecklist;
 using Application.UseCases.ExportChecklist;
 using Application.UseCases.ExportChecklist.Markdown;
+using Application.UseCases.GetChecklistsByIds;
 using Application.UseCases.GetPublishedChecklist;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -21,6 +21,7 @@ public sealed class ChecklistController : BaseController
     private readonly DeleteChecklistCommandHandler _deleteHandler;
     private readonly EditChecklistCommandHandler _editHandler;
     private readonly ExportMarkdownQueryHandler _exportHandler;
+    private readonly GetChecklistsByIdsQueryHandler _getByIdsHandler;
     private readonly IChecklistReadOnlyRepository _readRepository;
     private readonly ILogger<ChecklistController> _logger;
 
@@ -30,6 +31,7 @@ public sealed class ChecklistController : BaseController
         DeleteChecklistCommandHandler deleteHandler,
         EditChecklistCommandHandler editHandler,
         ExportMarkdownQueryHandler exportHandler,
+        GetChecklistsByIdsQueryHandler getByIdsHandler,
         IChecklistReadOnlyRepository readRepository,
         ILogger<ChecklistController> logger)
     {
@@ -38,6 +40,7 @@ public sealed class ChecklistController : BaseController
         _deleteHandler = deleteHandler;
         _editHandler = editHandler;
         _exportHandler = exportHandler;
+        _getByIdsHandler = getByIdsHandler;
         _readRepository = readRepository;
         _logger = logger;
     }
@@ -294,5 +297,38 @@ public sealed class ChecklistController : BaseController
         }
 
         return BadRequest(result.ErrorMessage ?? "An error occurred while updating the checklist.");
+    }
+
+    [HttpPost("get-by-ids")]
+    public async Task<IActionResult> GetByIds([FromBody] List<Guid> ids)
+    {
+        if (!ModelState.IsValid)
+        {
+            _logger.LogWarning("GetByIds validation failed");
+            return BadRequest(ModelState);
+        }
+
+        if (ids == null || ids.Count == 0)
+        {
+            _logger.LogInformation("GetByIds requested with empty list");
+            return Json(new List<object>());
+        }
+
+        _logger.LogInformation(
+            "Fetching multiple checklists by IDs. Count: {Count}",
+            ids.Count);
+
+        var query = new GetChecklistsByIdsQuery(ids);
+        var result = await _getByIdsHandler.HandleAsync(query);
+
+        if (!result.Succeeded)
+        {
+            _logger.LogWarning(
+                "Failed to fetch checklists by IDs: {Error}",
+                result.ErrorMessage);
+            return BadRequest(result.ErrorMessage);
+        }
+
+        return Json(result.Value);
     }
 }

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -10,6 +10,7 @@ using Application.UseCases.CreateChecklist;
 using Application.UseCases.DeleteChecklist;
 using Application.UseCases.EditChecklist;
 using Application.UseCases.ExportChecklist.Markdown;
+using Application.UseCases.GetChecklistsByIds;
 using Application.UseCases.GetPublishedChecklist;
 using Application.UseCases.GetSystemStats;
 using Application.UseCases.GetUserChecklists;
@@ -95,6 +96,7 @@ builder.Services.AddScoped<EditChecklistCommandHandler>();
 builder.Services.AddScoped<GetSystemStatsQueryHandler>();
 builder.Services.AddScoped<ExportMarkdownQueryHandler>();
 builder.Services.AddScoped<ToggleChecklistStatusCommandHandler>();
+builder.Services.AddScoped<GetChecklistsByIdsQueryHandler>();
 
 builder.Services.AddControllersWithViews();
 

--- a/src/Web/Views/Home/Index.cshtml
+++ b/src/Web/Views/Home/Index.cshtml
@@ -2,6 +2,13 @@
     ViewData["Title"] = "Home Page";
 }
 
-<div class="text-center">
-    <h1 class="display-4">Welcome</h1>
+<div class="text-center mt-5 mb-5">
+    <h1 class="display-4">Welcome to Bogar Karba</h1>
+    <p class="lead">Your ultimate technical checklist tracker.</p>
 </div>
+
+<div id="progress-checklists-container" class="container"></div>
+
+@section Scripts {
+    <script src="~/js/home-progress.js" asp-append-version="true"></script>
+}

--- a/src/Web/wwwroot/js/home-progress.js
+++ b/src/Web/wwwroot/js/home-progress.js
@@ -1,0 +1,90 @@
+(function () {
+    "use strict";
+
+    const STORAGE_KEY = "bogarKarba.checklistProgress";
+
+    async function init() {
+        const container = document.getElementById("progress-checklists-container");
+        if (!container) return;
+
+        const rawData = localStorage.getItem(STORAGE_KEY);
+        if (!rawData) return;
+
+        let data;
+        try {
+            data = JSON.parse(rawData);
+        } catch (e) {
+            return;
+        }
+
+        if (!data || !data.checklists) return;
+
+        const ids = Object.keys(data.checklists);
+        if (ids.length === 0) return;
+
+        try {
+            const response = await fetch('/checklist/get-by-ids', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(ids)
+            });
+
+            if (!response.ok) return;
+
+            const checklists = await response.json();
+            if (checklists.length > 0) {
+                render(container, checklists, data.checklists);
+            }
+        } catch (error) {
+            console.error("Error loading progress:", error);
+        }
+    }
+
+    function render(container, checklists, progressData) {
+        let html = `
+            <div class="row">
+                <div class="col-12">
+                    <h2 class="h4 mb-4 border-bottom pb-2">Your Progress</h2>
+                </div>
+            </div>
+            <div class="row row-cols-1 row-cols-md-3 g-4 mb-5">
+        `;
+
+        checklists.forEach(item => {
+            const title = escapeHtml(item.title);
+            const desc = escapeHtml(item.description || "");
+            const url = `/checklist/${item.id}`;
+            
+            html += `
+                <div class="col">
+                    <div class="card h-100 shadow-sm border-primary">
+                        <div class="card-body d-flex flex-column">
+                            <h5 class="card-title">${title}</h5>
+                            <p class="card-text text-muted small flex-grow-1">${desc}</p>
+                            <div class="d-grid mt-3">
+                                <a href="${url}" class="btn btn-primary">Continue</a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            `;
+        });
+
+        html += `</div>`;
+        container.innerHTML = html;
+    }
+
+    function escapeHtml(str) {
+        const p = document.createElement('p');
+        p.textContent = str;
+        return p.innerHTML;
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();

--- a/tests/UnitTests/CloneChecklistCommandHandlerTests.cs
+++ b/tests/UnitTests/CloneChecklistCommandHandlerTests.cs
@@ -4,7 +4,6 @@ using Application.UseCases.CloneChecklist;
 using Domain.Entities;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
 
 namespace UnitTests;
 

--- a/tests/UnitTests/DeleteChecklistCommandHandlerTests.cs
+++ b/tests/UnitTests/DeleteChecklistCommandHandlerTests.cs
@@ -4,7 +4,6 @@ using Application.UseCases.DeleteChecklist;
 using Domain.Entities;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
 
 namespace UnitTests;
 

--- a/tests/UnitTests/GetChecklistsByIdsQueryHandlerTests.cs
+++ b/tests/UnitTests/GetChecklistsByIdsQueryHandlerTests.cs
@@ -1,0 +1,78 @@
+using Application.Interfaces;
+using Application.UseCases.GetChecklistsByIds;
+using Domain.Entities;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace UnitTests;
+
+public class GetChecklistsByIdsQueryHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_WithEmptyIds_ReturnsEmptyListAndDoesNotCallRepository()
+    {
+        // Arrange
+        var repositoryMock = new Mock<IChecklistRepository>();
+        var loggerMock = new Mock<ILogger<GetChecklistsByIdsQueryHandler>>();
+        var sut = new GetChecklistsByIdsQueryHandler(repositoryMock.Object, loggerMock.Object);
+
+        // Act
+        var result = await sut.HandleAsync(new GetChecklistsByIdsQuery(new List<Guid>()));
+
+        // Assert
+        Assert.True(result.Succeeded);
+        Assert.NotNull(result.Value);
+        Assert.Empty(result.Value);
+        repositoryMock.Verify(r => r.GetByIdsAsync(It.IsAny<IEnumerable<Guid>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithValidIds_ReturnsOnlyPublishedChecklists()
+    {
+        // Arrange
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        var checklists = new List<Checklist>
+        {
+            new Checklist { Id = id1, Title = "Published", Status = ChecklistStatus.Published },
+            new Checklist { Id = id2, Title = "Draft", Status = ChecklistStatus.Draft }
+        };
+
+        var repositoryMock = new Mock<IChecklistRepository>();
+        repositoryMock.Setup(r => r.GetByIdsAsync(It.IsAny<IEnumerable<Guid>>()))
+            .ReturnsAsync(checklists);
+
+        var loggerMock = new Mock<ILogger<GetChecklistsByIdsQueryHandler>>();
+        var sut = new GetChecklistsByIdsQueryHandler(repositoryMock.Object, loggerMock.Object);
+
+        // Act
+        var result = await sut.HandleAsync(new GetChecklistsByIdsQuery(new List<Guid> { id1, id2 }));
+
+        // Assert
+        Assert.True(result.Succeeded);
+        Assert.NotNull(result.Value);
+        Assert.Single(result.Value);
+        Assert.Equal(id1, result.Value[0].Id);
+        Assert.Equal(ChecklistStatus.Published, result.Value[0].Status);
+        repositoryMock.Verify(r => r.GetByIdsAsync(It.IsAny<IEnumerable<Guid>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenRepositoryReturnsNothing_ReturnsEmptyList()
+    {
+        // Arrange
+        var repositoryMock = new Mock<IChecklistRepository>();
+        repositoryMock.Setup(r => r.GetByIdsAsync(It.IsAny<IEnumerable<Guid>>()))
+            .ReturnsAsync(new List<Checklist>());
+
+        var loggerMock = new Mock<ILogger<GetChecklistsByIdsQueryHandler>>();
+        var sut = new GetChecklistsByIdsQueryHandler(repositoryMock.Object, loggerMock.Object);
+
+        // Act
+        var result = await sut.HandleAsync(new GetChecklistsByIdsQuery(new List<Guid> { Guid.NewGuid() }));
+
+        // Assert
+        Assert.True(result.Succeeded);
+        Assert.Empty(result.Value!);
+    }
+}

--- a/tests/UnitTests/GetSystemStatsQueryHandlerTests.cs
+++ b/tests/UnitTests/GetSystemStatsQueryHandlerTests.cs
@@ -2,7 +2,6 @@ using Application.Interfaces;
 using Application.UseCases.GetSystemStats;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
 
 namespace UnitTests;
 

--- a/tests/UnitTests/GetUserChecklistsQueryHandlerTests.cs
+++ b/tests/UnitTests/GetUserChecklistsQueryHandlerTests.cs
@@ -3,7 +3,6 @@ using Application.UseCases.GetUserChecklists;
 using Domain.Entities;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
 
 namespace UnitTests;
 

--- a/tests/UnitTests/JsTestsRunner.cs
+++ b/tests/UnitTests/JsTestsRunner.cs
@@ -1,6 +1,4 @@
 using System.Diagnostics;
-using Xunit;
-using Xunit.Abstractions;
 
 namespace UnitTests;
 

--- a/tests/UnitTests/SearchChecklistsQueryHandlerTests.cs
+++ b/tests/UnitTests/SearchChecklistsQueryHandlerTests.cs
@@ -2,7 +2,6 @@ using Application.Interfaces;
 using Application.UseCases.SearchChecklists;
 using Domain.Entities;
 using Microsoft.Extensions.Logging.Abstractions;
-using Xunit;
 
 namespace UnitTests;
 
@@ -103,6 +102,12 @@ public class SearchChecklistsQueryHandlerTests
         public Task<IEnumerable<Checklist>> GetByUserIdAsync(string userId)
         {
             return Task.FromResult<IEnumerable<Checklist>>(_items.Where(c => c.UserId == userId));
+        }
+
+        public Task<List<Checklist>> GetByIdsAsync(IEnumerable<Guid> ids)
+        {
+            var idSet = ids.ToHashSet();
+            return Task.FromResult(_items.Where(c => idSet.Contains(c.Id)).ToList());
         }
 
         public Task AddAsync(Checklist checklist)

--- a/tests/UnitTests/ToggleChecklistStatusCommandHandlerTests.cs
+++ b/tests/UnitTests/ToggleChecklistStatusCommandHandlerTests.cs
@@ -4,7 +4,6 @@ using Application.UseCases.ToggleChecklistStatus;
 using Domain.Entities;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
 
 namespace UnitTests;
 


### PR DESCRIPTION
Implemented the "Home Page Progress Tracking" use case, allowing both guests and authors to see their active checklists directly on the main page based on local progress.

Key Changes:

- Application:

  - Implemented GetChecklistsByIdsQuery and GetChecklistsByIdsQueryHandler to fetch checklist metadata for specific IDs.
  - Added GetByIdsAsync method to IChecklistRepository.
  - Ensured that only checklists with ChecklistStatus.Published are returned to maintain data consistency.
  - Integrated the logic with the existing unified Result<T> pattern.

- Infrastructure:
  - Implemented GetByIdsAsync in ChecklistRepository using EF Core with .AsNoTracking() for optimized read performance.

- Web:
  - Added GetByIds POST action to ChecklistController to handle batch requests from the frontend.
  - Created home-progress.js to handle localStorage synchronization and dynamic UI rendering.
  - Updated Home/Index.cshtml by adding a dedicated container for the progress section and integrating the synchronization script.
  - Ensured the "Your Progress" section is only displayed when active progress exists in the browser.

- Testing:
  - Added unit tests for GetChecklistsByIdsQueryHandler using Moq.
  - Updated FakeChecklistRepository in existing tests to conform to the updated IChecklistRepository interface.
  - Verified all 74 tests pass successfully.